### PR TITLE
Change the default behaviour to always be visible

### DIFF
--- a/TORoundedTableView/TORoundedTableView.h
+++ b/TORoundedTableView/TORoundedTableView.h
@@ -30,7 +30,7 @@
 /** Shows the rounded corners. Setting to NO will show the original edge-to-edge visual style. (Default is YES) */
 @property (nonatomic, assign) BOOL showRoundedCorners;
 
-/** The distance from the edges of each side of the table view (Default is 22 points) */
+/** The distance from the edges of each side of the table view (Default is 18 points) */
 @property (nonatomic, assign) CGFloat horizontalInset;
 
 /** From the edge of the table view cells, the horizontal inset of the accessory views. (Default is an un-used value.) */
@@ -39,7 +39,7 @@
 /** The maximum width that the table content may be scale to (Default is 675) */
 @property (nonatomic, assign) CGFloat maximumWidth;
 
-/** The corner radius of each section (Default value is 5) */
+/** The corner radius of each section (Default value is 7) */
 @property (nonatomic, assign) CGFloat sectionCornerRadius;
 
 /** The default background color of every cell (Default color is white) */

--- a/TORoundedTableView/TORoundedTableView.h
+++ b/TORoundedTableView/TORoundedTableView.h
@@ -27,6 +27,9 @@
 
 @interface TORoundedTableView : UITableView
 
+/** Shows the rounded corners. Setting to NO will show the original edge-to-edge visual style. (Default is YES) */
+@property (nonatomic, assign) BOOL showRoundedCorners;
+
 /** The distance from the edges of each side of the table view (Default is 22 points) */
 @property (nonatomic, assign) CGFloat horizontalInset;
 

--- a/TORoundedTableView/TORoundedTableView.m
+++ b/TORoundedTableView/TORoundedTableView.m
@@ -135,8 +135,9 @@ static inline void TORoundedTableViewResizeAccessoryView(UITableViewHeaderFooter
 
 - (void)setUp
 {
-    _sectionCornerRadius = 5.0f;
-    _horizontalInset = 22.0f;
+    _showRoundedCorners = YES;
+    _sectionCornerRadius = 7.0f;
+    _horizontalInset = 18.0f;
     _maximumWidth = 675.0f;
     _cellBackgroundColor = [UIColor whiteColor];
     _cellSelectedBackgroundColor = TOROUNDEDTABLEVIEW_SELECTED_BACKGROUND_COLOR;
@@ -198,7 +199,8 @@ static inline void TORoundedTableViewResizeAccessoryView(UITableViewHeaderFooter
 {
     [super layoutSubviews];
 
-    if (self.traitCollection.horizontalSizeClass != UIUserInterfaceSizeClassRegular) {
+    // Skip if we've disabled showing the rounded corners
+    if (!self.showRoundedCorners) {
         return;
     }
 
@@ -230,7 +232,7 @@ static inline void TORoundedTableViewResizeAccessoryView(UITableViewHeaderFooter
     // Annoying hack. While other views automatically resize/reposition when adjusting between size classes,
     // the table footer view doesn't move back to its origin of 0.0
     // This forcibly resets the position of the footer view
-    if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact && self.tableFooterView) {
+    if (!self.showRoundedCorners && self.tableFooterView) {
         CGRect frame = self.tableFooterView.frame;
         frame.origin.x = 0.0f;
         self.tableFooterView.frame = frame;

--- a/TORoundedTableView/TORoundedTableViewCapCell.m
+++ b/TORoundedTableView/TORoundedTableViewCapCell.m
@@ -115,11 +115,12 @@
         backgroundViewFrame.size.height += 1.0f;
         self.backgroundView.frame = backgroundViewFrame;
     }
-    
-    if (self.traitCollection.horizontalSizeClass != UIUserInterfaceSizeClassRegular) {
+
+    // Check if we're enabled or not by seeing if we are stretching edge-to-edge
+    if (self.frame.size.width >= self.superview.frame.size.width - FLT_EPSILON) {
         return;
     }
-    
+
     // Hide the exterior separator view
     // Search for any section exterior separator views that were added and hide them
     for (UIView *view in self.subviews) {

--- a/TORoundedTableView/TORoundedTableViewCapCell.m
+++ b/TORoundedTableView/TORoundedTableViewCapCell.m
@@ -117,7 +117,12 @@
     }
 
     // Check if we're enabled or not by seeing if we are stretching edge-to-edge
-    if (self.frame.origin.x <= FLT_EPSILON) {
+    // Account for the invisible container view on iOS 10 and below
+    UIView *containerView = self;
+    if (@available(iOS 11.0, *)) { }
+    else { containerView = self.superview; }
+
+    if (containerView.frame.origin.x <= FLT_EPSILON) {
         return;
     }
 

--- a/TORoundedTableView/TORoundedTableViewCapCell.m
+++ b/TORoundedTableView/TORoundedTableViewCapCell.m
@@ -117,7 +117,7 @@
     }
 
     // Check if we're enabled or not by seeing if we are stretching edge-to-edge
-    if (self.frame.size.width >= self.superview.frame.size.width - FLT_EPSILON) {
+    if (self.frame.origin.x <= FLT_EPSILON) {
         return;
     }
 

--- a/TORoundedTableView/TORoundedTableViewCell.m
+++ b/TORoundedTableView/TORoundedTableViewCell.m
@@ -29,9 +29,6 @@ static Class _tableViewClass = NULL;
 
 - (void)setFrame:(CGRect)frame
 {
-    if (!_tableViewClass) { _tableViewClass = [TORoundedTableView class]; }
-    BOOL horizontalRegular = self.traitCollection.horizontalSizeClass != UIUserInterfaceSizeClassCompact;
-
     /** On iOS 10 and down, table cells are kept in `UITableViewWrapperView`,
      which abstracts away our control of the frame from `TORoundedTableView`.
      As such, it's necessary to override `setFrame` and force the cell width to match
@@ -40,7 +37,8 @@ static Class _tableViewClass = NULL;
      On iOS 11, that is no longer the case. Cells are direct subviews of the table view.
      As such, this isn't necessary anymore.
      */
-    if (![self.superview isKindOfClass:_tableViewClass] && horizontalRegular) {
+    if (!_tableViewClass) { _tableViewClass = [TORoundedTableView class]; }
+    if (![self.superview isKindOfClass:_tableViewClass]) {
         frame.size.width = self.superview.frame.size.width;
     }
 

--- a/TORoundedTableView/TORoundedTableViewCellBackground.m
+++ b/TORoundedTableView/TORoundedTableViewCellBackground.m
@@ -98,8 +98,13 @@ typedef NS_ENUM(NSInteger, TORoundedTableViewCellBackgroundCorner) {
 {
     [super layoutSubviews];
 
+    // On iOS 10 and below, there is an additional container view we need to hook
+    UIView *containerView = self.superview;
+    if (@available(iOS 11.0, *)) { }
+    else { containerView = self.superview.superview; }
+
     // Check if we're enabled or not by seeing if we are stretching edge-to-edge
-    BOOL hideRoundedCorners = (self.superview.frame.origin.x <= FLT_EPSILON);
+    BOOL hideRoundedCorners = (containerView.frame.origin.x <= FLT_EPSILON);
 
     CABasicAnimation *resizeAnimation = (CABasicAnimation *)[self.layer animationForKey:@"bounds.size"];
     if (resizeAnimation == nil) {

--- a/TORoundedTableView/TORoundedTableViewCellBackground.m
+++ b/TORoundedTableView/TORoundedTableViewCellBackground.m
@@ -99,7 +99,7 @@ typedef NS_ENUM(NSInteger, TORoundedTableViewCellBackgroundCorner) {
     [super layoutSubviews];
 
     // Check if we're enabled or not by seeing if we are stretching edge-to-edge
-    BOOL hideRoundedCorners = (self.frame.size.width >= self.superview.frame.size.width - FLT_EPSILON);
+    BOOL hideRoundedCorners = (self.superview.frame.origin.x <= FLT_EPSILON);
 
     CABasicAnimation *resizeAnimation = (CABasicAnimation *)[self.layer animationForKey:@"bounds.size"];
     if (resizeAnimation == nil) {

--- a/TORoundedTableView/TORoundedTableViewCellBackground.m
+++ b/TORoundedTableView/TORoundedTableViewCellBackground.m
@@ -97,9 +97,10 @@ typedef NS_ENUM(NSInteger, TORoundedTableViewCellBackgroundCorner) {
 - (void)layoutSubviews
 {
     [super layoutSubviews];
-    
-    BOOL isCompactSizeClass = (self.superview.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact);
-    
+
+    // Check if we're enabled or not by seeing if we are stretching edge-to-edge
+    BOOL hideRoundedCorners = (self.frame.size.width >= self.superview.frame.size.width - FLT_EPSILON);
+
     CABasicAnimation *resizeAnimation = (CABasicAnimation *)[self.layer animationForKey:@"bounds.size"];
     if (resizeAnimation == nil) {
         resizeAnimation = (CABasicAnimation *)[self.layer animationForKey:@"bounds"];
@@ -116,11 +117,11 @@ typedef NS_ENUM(NSInteger, TORoundedTableViewCellBackgroundCorner) {
     CALayer *topRightCornerLayer = self.cornerLayers[TORoundedTableViewCellBackgroundCornerTopRight];
     CALayer *topLayer = self.layers[TORoundedTableViewCellBackgroundViewTop];
     
-    topLeftCornerLayer.hidden  = !self.topCornersRounded || isCompactSizeClass;
-    topRightCornerLayer.hidden = !self.topCornersRounded || isCompactSizeClass;
-    topLayer.hidden            = !self.topCornersRounded || isCompactSizeClass;
+    topLeftCornerLayer.hidden  = !self.topCornersRounded || hideRoundedCorners;
+    topRightCornerLayer.hidden = !self.topCornersRounded || hideRoundedCorners;
+    topLayer.hidden            = !self.topCornersRounded || hideRoundedCorners;
     
-    if (self.topCornersRounded && !isCompactSizeClass) {
+    if (self.topCornersRounded && !hideRoundedCorners) {
         frame = (CGRect){CGPointZero, cornerLayerSize};
         [self animateLayer:topLeftCornerLayer forNewFrame:frame fromAnimation:resizeAnimation];
         topLeftCornerLayer.frame = frame;
@@ -140,12 +141,12 @@ typedef NS_ENUM(NSInteger, TORoundedTableViewCellBackgroundCorner) {
     
     // Layout out the middle rect
     frame = self.bounds;
-    if (self.topCornersRounded && !isCompactSizeClass) {
+    if (self.topCornersRounded && !hideRoundedCorners) {
         frame.origin.y += cornerLayerSize.height;
         frame.size.height -= cornerLayerSize.height;
     }
     
-    if (self.bottomCornersRounded && !isCompactSizeClass) {
+    if (self.bottomCornersRounded && !hideRoundedCorners) {
         frame.size.height -= cornerLayerSize.height;
     }
     
@@ -157,11 +158,11 @@ typedef NS_ENUM(NSInteger, TORoundedTableViewCellBackgroundCorner) {
     CALayer *bottomRightCornerLayer = self.cornerLayers[TORoundedTableViewCellBackgroundCornerBottomRight];
     CALayer *bottomLayer            = self.layers[TORoundedTableViewCellBackgroundViewBottom];
     
-    bottomLeftCornerLayer.hidden    = !self.bottomCornersRounded || isCompactSizeClass;
-    bottomRightCornerLayer.hidden   = !self.bottomCornersRounded || isCompactSizeClass;
-    bottomLayer.hidden              = !self.bottomCornersRounded || isCompactSizeClass;
+    bottomLeftCornerLayer.hidden    = !self.bottomCornersRounded || hideRoundedCorners;
+    bottomRightCornerLayer.hidden   = !self.bottomCornersRounded || hideRoundedCorners;
+    bottomLayer.hidden              = !self.bottomCornersRounded || hideRoundedCorners;
     
-    if (self.bottomCornersRounded && !isCompactSizeClass) {
+    if (self.bottomCornersRounded && !hideRoundedCorners) {
         frame = self.bounds;
         frame.origin.y = boundsSize.height - cornerLayerSize.height;
         frame.size = cornerLayerSize;

--- a/TORoundedTableViewTests/TORoundedTableViewTests.m
+++ b/TORoundedTableViewTests/TORoundedTableViewTests.m
@@ -30,10 +30,10 @@
     TORoundedTableView *tableView = [[TORoundedTableView alloc] initWithFrame:CGRectZero];
     XCTAssertNotNil(tableView);
 
-    XCTAssertEqual(tableView.horizontalInset, 22.0f);
+    XCTAssertEqual(tableView.horizontalInset, 18.0f);
     XCTAssertEqual(tableView.accessoryHorizontalInset, MAXFLOAT);
     XCTAssertEqual(tableView.maximumWidth, 675.0f);
-    XCTAssertEqual(tableView.sectionCornerRadius, 5.0f);
+    XCTAssertEqual(tableView.sectionCornerRadius, 7.0f);
     XCTAssertEqual(tableView.cellBackgroundColor, [UIColor whiteColor]);
 }
 


### PR DESCRIPTION
After seeing how common this effect became on iOS 13, it doesn't seem to be unacceptable to have rounded corners on screen sizes as small as iPhone SE anymore.

This PR will make the effect always on, with the optional setting to turn it off.